### PR TITLE
Clamp fractional byte inputs in byte helper

### DIFF
--- a/grAESecure.gs
+++ b/grAESecure.gs
@@ -85,13 +85,17 @@ AESLIB.BYTES._charmap = AESLIB.BYTES._build_charmap()
 
 // Clamp helper (keep yours if already present)
 AESLIB.BYTES._b = function(x)
-    if x < 0 then 
-        return 0 
+    if typeof(x) != "number" then
+        return 0
     end if
-    if x > 255 then 
-        return x % 256 
+    n = floor(x)
+    if n < 0 then
+        return 0
     end if
-    return x
+    if n > 255 then
+        return n % 256
+    end if
+    return n
 end function
 
 // Robust 1-char/number → byte

--- a/grAESecure_test.gs
+++ b/grAESecure_test.gs
@@ -216,18 +216,27 @@ else
     FAIL("BYTES raw round-trip")
 end if
 
-// ---------- 3) S-box inverse ----------
+// ---------- 3) BYTES to_hex clamps non-integers ----------
+frac = [1.9, 255.9]
+frac_hex = AESLIB.BYTES.to_hex(frac)
+if frac_hex == "01ff" then
+    OK("BYTES to_hex clamps non-integers")
+else
+    FAIL("BYTES to_hex clamps non-integers")
+end if
+
+// ---------- 4) S-box inverse ----------
 OK("S-box inverse")
 
-// ---------- 4) GF xtime/gmul sanity ----------
+// ---------- 5) GF xtime/gmul sanity ----------
 OK("GF xtime/gmul sanity")
 
-// ---------- 5) KeyExpansion (skipped: expand_key not exposed) ----------
+// ---------- 6) KeyExpansion (skipped: expand_key not exposed) ----------
 key_pw = "testkey-256"
 key32  = AESLIB.BYTES.key32_from_password(key_pw)
 OK("KeyExpansion (skipped: expand_key not exposed)")
 
-// ---------- 6) Encrypt/Decrypt single block (skipped if no expand_key) ----------
+// ---------- 7) Encrypt/Decrypt single block (skipped if no expand_key) ----------
 if AES256 != null then
     if MAP_has(AES256, "expand_key") then
         blk = []
@@ -251,7 +260,7 @@ else
     OK("Encrypt/Decrypt single block (skipped: AES256 not exposed)")
 end if
 
-// ---------- 7) PKCS#7 pad/unpad ----------
+// ---------- 8) PKCS#7 pad/unpad ----------
 msg = AESLIB.BYTES.str_to_bytes("PKCS7 test 12345")
 padded   = PKCS7_pad(msg, 16)
 unpadded = PKCS7_unpad(padded, 16)
@@ -267,7 +276,7 @@ else
     FAIL("PKCS#7 pad/unpad")
 end if
 
-// ---------- 8) CBC enc/dec ----------
+// ---------- 9) CBC enc/dec ----------
 cbc_pt  = AESLIB.BYTES.str_to_bytes("The quick brown fox jumps over the lazy dog.")
 cbc_iv  = AESLIB.BYTES.random_bytes(16)
 cbc_ct  = AESLIB.MODES.cbc_encrypt(cbc_pt, key32, cbc_iv)
@@ -278,7 +287,7 @@ else
     FAIL("CBC enc/dec mismatch ct_len=" + str(len(cbc_ct)) + " ct_hex=" + hex(cbc_ct))
 end if
 
-/// ---------- 9) CTR enc/dec (arity-aware; no probing by calling) ----------
+/// ---------- 10) CTR enc/dec (arity-aware; no probing by calling) ----------
 MODES = null
 if MAP_has(AESLIB, "MODES") then
     MODES = MAP_get(AESLIB, "MODES")
@@ -342,7 +351,7 @@ else
     end if
 end if
 
-// ---------- 10) sealed_cbc (2-arg shim; skip if not exposed) ----------
+// ---------- 11) sealed_cbc (2-arg shim; skip if not exposed) ----------
 did_sealed = false
 if MODES != null then
     raw_seal = null


### PR DESCRIPTION
## Summary
- Ensure AESLIB.BYTES._b clamps to integers before bounding to 0..255
- Add regression test for handling fractional bytes in to_hex and renumber tests

## Testing
- `node grAESecure_test.gs` *(fails: SyntaxError: Unexpected identifier 'not')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2d2e8df0832f854177060bcfe40d