### PR TITLE
fix: guard pad type in pkcs7_unpad

### DIFF
--- a/grAESecure.gs
+++ b/grAESecure.gs
@@ -617,10 +617,13 @@ AESLIB.MODES.pkcs7_pad = function(bytes, block)
 end function
 
 AESLIB.MODES.pkcs7_unpad = function(bytes, block)
-    if len(bytes) == 0 then 
-        return [] 
+    if len(bytes) == 0 then
+        return []
     end if
     pad = bytes[len(bytes)-1]
+    if typeof(pad) != "number" then
+        return []
+    end if
     if pad <= 0 or pad > block then
         // bad pad: return original (or empty)
         return []


### PR DESCRIPTION
## Summary
- guard `pkcs7_unpad` against non-numeric pad values before comparisons

## Testing
- `greyscript grAESecure_test.gs` *(fails: command not found)*
- `node grAESecure_test.gs` *(fails: SyntaxError: Unexpected identifier 'not')*

------
https://chatgpt.com/codex/tasks/task_e_68ab419c94a8832f853a3d674ecb7bf4