### PR TITLE
test: validate S-box inverse

### DIFF
--- a/grAESecure_test.gs
+++ b/grAESecure_test.gs
@@ -223,7 +223,6 @@ while i < 256
     sb = AES256.s_box[i]
     inv = AES256.inv_s_box[sb]
     if inv != i then
-        FAIL("S-box inverse")
         ok_inv = false
         break
     end if
@@ -231,6 +230,8 @@ while i < 256
 end while
 if ok_inv then
     OK("S-box inverse")
+else
+    FAIL("S-box inverse")
 end if
 
 // ---------- 4) GF xtime/gmul sanity ----------

--- a/grAESecure_test.gs
+++ b/grAESecure_test.gs
@@ -217,7 +217,21 @@ else
 end if
 
 // ---------- 3) S-box inverse ----------
-OK("S-box inverse")
+i = 0
+ok_inv = true
+while i < 256
+    sb = AES256.s_box[i]
+    inv = AES256.inv_s_box[sb]
+    if inv != i then
+        FAIL("S-box inverse")
+        ok_inv = false
+        break
+    end if
+    i = i + 1
+end while
+if ok_inv then
+    OK("S-box inverse")
+end if
 
 // ---------- 4) GF xtime/gmul sanity ----------
 OK("GF xtime/gmul sanity")


### PR DESCRIPTION
## Summary
- add exhaustive check ensuring AES S-box and inverse mapping are consistent

## Testing
- `node grAESecure_test.gs` *(fails: SyntaxError: Unexpected identifier 'not')*

------
https://chatgpt.com/codex/tasks/task_e_68ab41a3b2e8832fb63c3fdc42ac162c