### PR TITLE
docs: fix status heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Features:
 - Simple password-to-key derivation
 - Built-in self-tests for correctness
 
-## StatStatus
+## Status
 - ✅ Compiles and passes self-tests (grAESecure_test.src)
 - ⚠️ KDF and MAC are minimal (see Roadmap)
 


### PR DESCRIPTION
## Summary
- fix README typo in status heading

## Testing
- `node grAESecure_test.gs` *(fails: SyntaxError: Unexpected identifier 'not')*


------
https://chatgpt.com/codex/tasks/task_e_68ab43f68a88832f8d4b7c99c7fb41b6